### PR TITLE
Windows compilation part.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 2.6)
 project(usbwall C)
 
+set(USB1_INCLUDE_DIR "/usr/include/libusb-1.0/")
+set(USB1_LIBRARIES "libusb.h")
+
+set(LDAP_INCLUDE_DIR "/usr/include/")
+set(LDAP_LIBRARY "ldap.h")
+
+set(PAM_INCLUDE_DIR "/usr/include/security/")
+set(PAM_LIBRARY "pam_modules.h")
+
+#add_executable(myexe USB1::USB1)
+
 set(USBWALL_VERSION 0.4)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/Modules/)

--- a/bootstrap
+++ b/bootstrap
@@ -3,6 +3,8 @@
 SCRIPT=$(readlink -f "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 BUILDDIR="$SCRIPTPATH/_build"
+MINGWGCC="/usr/bin/x86_64-w64-mingw32-gcc"
+TOOLCHAIN=toolchain-mingw.cmake
 
 # define build mode
 if [ "$1" = "DEBUG" ]; then
@@ -19,4 +21,4 @@ mkdir -p $BUILDDIR
 
 # launch cmake
 echo "launching cmake in $BUILDDIR mode=$MODE"
-cd $BUILDDIR && cmake .. -DCMAKE_BUILD_TYPE=$MODE
+cd $BUILDDIR && cmake .. -DCMAKE_C_COMPILER=$MINGWGCC -DCMAKE_TOOLCHAIN_FILE=$TOOLCHAIN -DCMAKE_BUILD_TYPE=$MODE

--- a/toolchain-mingw.cmake
+++ b/toolchain-mingw.cmake
@@ -1,0 +1,33 @@
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Windows)
+
+# Choose an appropriate compiler prefix
+
+# for classical mingw32
+# see http://www.mingw.org/
+#set(COMPILER_PREFIX "i586-mingw32msvc")
+
+# for 32 or 64 bits mingw-w64
+# see http://mingw-w64.sourceforge.net/
+#set(COMPILER_PREFIX "i686-w64-mingw32")
+set(COMPILER_PREFIX "x86_64-w64-mingw32")
+
+# which compilers to use for C and C++
+find_program(CMAKE_RC_COMPILER NAMES ${COMPILER_PREFIX}-windres)
+#SET(CMAKE_RC_COMPILER ${COMPILER_PREFIX}-windres)
+find_program(CMAKE_C_COMPILER NAMES ${COMPILER_PREFIX}-gcc)
+#SET(CMAKE_C_COMPILER ${COMPILER_PREFIX}-gcc)
+find_program(CMAKE_CXX_COMPILER NAMES ${COMPILER_PREFIX}-g++)
+#SET(CMAKE_CXX_COMPILER ${COMPILER_PREFIX}-g++)
+
+
+# here is the target environment located
+SET(USER_ROOT_PATH /home/erk/erk-win32-dev)
+SET(CMAKE_FIND_ROOT_PATH  /usr/${COMPILER_PREFIX} ${USER_ROOT_PATH})
+
+# adjust the default behaviour of the FIND_XXX() commands:
+# search headers and libraries in the target environment, search 
+# programs in the host environment
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
Did a few modifications to use MinGW in order to compile easily our code for the Windows platform on a Linux architecture. Here The Bootstrap file has been modified to use the MinGW's gcc. We had to add a toolchain-mingw.cmake to specify to cmake that we are compiling for Windows. The CMakeLists file has been updated to specify the correct path of used binaries.